### PR TITLE
lime_settings: add missing cstdint include

### DIFF
--- a/src/lime_settings.hpp
+++ b/src/lime_settings.hpp
@@ -20,6 +20,8 @@
 #ifndef lime_settings_hpp
 #define lime_settings_hpp
 
+#include <cstdint>
+
 namespace lime {
 /** @brief Hold constants definition used as settings in all components of the lime library
  *


### PR DESCRIPTION
Without this, the build fails:

```
In file included from /build/lime/src/lime-5.2.32/src/lime_double_ratchet.hpp:28,
                 from /build/lime/src/lime-5.2.32/src/lime_double_ratchet.cpp:21:
/build/lime/src/lime-5.2.32/src/lime_settings.hpp:49:24: error: ‘uint16_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   49 |         constexpr std::uint16_t maxMessageSkip=1024;
      |                        ^~~~~~~~
      |                        wint_t
/build/lime/src/lime-5.2.32/src/lime_settings.hpp:54:24: error: ‘uint16_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   54 |         constexpr std::uint16_t maxMessagesReceivedAfterSkip = 128;
      |                        ^~~~~~~~
      |                        wint_t
/build/lime/src/lime-5.2.32/src/lime_settings.hpp:62:24: error: ‘uint16_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
   62 |         constexpr std::uint16_t maxSendingChain=1000;
      |                        ^~~~~~~~
      |                        wint_t
/build/lime/src/lime-5.2.32/src/lime_double_ratchet.cpp: In member function ‘void lime::DR<Curve>::ratchetEncrypt(const inputContainer&, std::vector<unsigned char>&&, std::vector<unsigned char>&, bool)’:
/build/lime/src/lime-5.2.32/src/lime_double_ratchet.cpp:345:45: error: ‘maxSendingChain’ is not a member of ‘lime::settings’
  345 |                 if (m_Ns >= lime::settings::maxSendingChain) { // if we reached maximum encryption wuthout DH ratchet step, session becomes inactive
      |                                             ^~~~~~~~~~~~~~~
/build/lime/src/lime-5.2.32/src/lime_double_ratchet.cpp: In member function ‘bool lime::DR<Curve>::ratchetDecrypt(const std::vector<unsigned char>&, const std::vector<unsigned char>&, outputContainer&, bool)’:
/build/lime/src/lime-5.2.32/src/lime_double_ratchet.cpp:389:60: error: ‘maxMessageSkip’ is not a member of ‘lime::settings’
  389 |                 int maxAllowedDerivation = lime::settings::maxMessageSkip;
      |                                                            ^~~~~~~~~~~~~~
/build/lime/src/lime-5.2.32/src/lime_double_ratchet.cpp:413:78: error: ‘maxMessageSkip’ is not a member of ‘lime::settings’
  413 |                                 skipMessageKeys(header.PN(), lime::settings::maxMessageSkip-header.Ns()); // we must keep header.Ns derivations available for the next chain
      |                                                                              ^~~~~~~~~~~~~~
```